### PR TITLE
Fix logging of invalid Unicode data

### DIFF
--- a/src/twig_event_handler.erl
+++ b/src/twig_event_handler.erl
@@ -101,7 +101,7 @@ write(Level, MsgId, Msg, Pid, State) when is_list(Msg); is_binary(Msg) ->
     send(Socket, Host, Port, [Pre, Msg, $\n]).
 
 send(_, undefined, _, Packet) ->
-    io:put_chars(Packet);
+    io:format("~s", [Packet]);
 send(Socket, Host, Port, Packet) ->
     gen_udp:send(Socket, Host, Port, Packet).
 


### PR DESCRIPTION
The io:put_chars/1 function attempts to handle unicode conversions. This
would break when attempting to log a binary like <<255>> (which happens
to exist in #view_query_args{}). This just switches the call to
io:format/2 which does no Unicode conversion.

This bug should only affect dbcore nodes where no rsyslog host is
specified (namely, local development clusters).

BugzId: 30437
